### PR TITLE
Update docker provider namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 terraform {
   required_providers {
     docker = {
-      source = "terraform-providers/docker"
+      source = "kreuzwerker/docker"
     }
     null = {
       source = "hashicorp/null"


### PR DESCRIPTION
It has moved from terraform-providers/docker to kreuzwerker/docker